### PR TITLE
Update regex

### DIFF
--- a/git/prefix-your-commit-message-2020-06-16.md
+++ b/git/prefix-your-commit-message-2020-06-16.md
@@ -9,7 +9,7 @@ vim .git/hooks/prepare-commit-msg
 
 FILE=$1
 MESSAGE=$(cat $FILE)
-TICKET=$(git rev-parse --abbrev-ref HEAD | grep -Eo '^(\w+/)?(\w+[-_])?[0-9]+' | grep -Eo '(\w+[-])?[0-9]+' | tr "[:lower:]" "[:upper:]")
+TICKET=$(git rev-parse --abbrev-ref HEAD | grep -Eo '^(\w+\/)?(\w+[-_])?[0-9]+' | grep -Eo '(\w+[-])?[0-9]+' | tr "[:lower:]" "[:upper:]")
 if [[ $TICKET == "" || "$MESSAGE" == "$TICKET"* ]];then
   exit 0;
 fi


### PR DESCRIPTION
Missing an escaped slash in the regex.

> An unescaped delimiter must be escaped with a backslash (\)